### PR TITLE
Get user details by id

### DIFF
--- a/steps/user-get-by-id/Dockerfile
+++ b/steps/user-get-by-id/Dockerfile
@@ -1,0 +1,9 @@
+FROM relaysh/core:latest-python
+RUN pip install pdpyras
+COPY "./step.py" "/entrypoint.py"
+ENTRYPOINT []
+CMD ["python3", "/entrypoint.py"]
+
+LABEL "org.opencontainers.image.title"="PagerDuty User details by id"
+LABEL "org.opencontainers.image.description"="This step gets the details of a user from PagerDuty"
+LABEL "com.puppet.nebula.sdk.version"="v1"

--- a/steps/user-get-by-id/README.md
+++ b/steps/user-get-by-id/README.md
@@ -13,14 +13,14 @@ This step expects the following fields in the `spec` section of a workflow step 
 
 ## Outputs
 
-| Name    | Data type | Description      |
-|---------|-----------|------------------|
-| `response` | Object    | not correct TODO |
-
-example output value:
-```json
-{"user":{"name":"Hunter Haugen","email":"hunter@puppet.com", ... }}
-```
+| Name          | Data type | Description                                               |
+|---------------|-----------|-----------------------------------------------------------|
+| `name`        | String    | The name of the user                                      |
+| `email`       | String    | The user's email address                                  |
+| `description` | String    | The user's bio                                            |
+| `timeZone`    | String    | The user's preferred time zone                            |
+| `apiURL`      | String    | The URL to the user record in the PagerDuty API           |
+| `appURL`      | String    | The URL to the user record in the PagerDuty web interface |
 
 
 ## Usage
@@ -30,4 +30,6 @@ steps:
 - name: pagerduty-user
   image: relaysh/pagerduty-step-user-get-by-id
   spec:
+    connection: !Connection [pagerduty, relay-pagerduty-service-integration]
+    userID: !Parameter userID
 ```

--- a/steps/user-get-by-id/README.md
+++ b/steps/user-get-by-id/README.md
@@ -1,0 +1,33 @@
+# user-get-by-id
+
+This step can be used to retrieve a user's details from [PagerDuty](http://pagerduty.com/).
+
+## Specification
+
+This step expects the following fields in the `spec` section of a workflow step definition that uses it:
+
+| Setting      | Data type        | Description                                       | Default | Required |
+|--------------|------------------|---------------------------------------------------|---------|----------|
+| `connection` | Relay connection | A pagerduty connection containing the admin token | None    | Yes      |
+| `userID`     | String           | The PagerDuty ID of the user to be looked up      | None    | Yes      |
+
+## Outputs
+
+| Name    | Data type | Description      |
+|---------|-----------|------------------|
+| `response` | Object    | not correct TODO |
+
+example output value:
+```json
+{"user":{"name":"Hunter Haugen","email":"hunter@puppet.com", ... }}
+```
+
+
+## Usage
+
+```yaml
+steps:
+- name: pagerduty-user
+  image: relaysh/pagerduty-step-user-get-by-id
+  spec:
+```

--- a/steps/user-get-by-id/outputs.schema.json
+++ b/steps/user-get-by-id/outputs.schema.json
@@ -1,0 +1,37 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "properties": {
+    "name": {
+      "type": "string",
+      "description": "The name of the user"
+    },
+    "email": {
+      "type": "string",
+      "description": "The user's email address",
+      "format": "email"
+    },
+    "description": {
+      "type": "string",
+      "description": "The user's bio"
+    },
+    "timeZone": {
+      "type": "string",
+      "description": "The user's preferred time zone"
+    },
+    "apiURL": {
+      "type": "string",
+      "description": "The URL to the user record in the PagerDuty API",
+      "format": "url"
+    },
+    "appURL": {
+      "type": "string",
+      "description": "The URL to the user record in the PagerDuty web interface",
+      "format": "url"
+    }
+  },
+  "required": [
+    "name",
+    "email"
+  ]
+}

--- a/steps/user-get-by-id/spec.schema.json
+++ b/steps/user-get-by-id/spec.schema.json
@@ -1,0 +1,28 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "properties": {
+    "connection": {
+      "type": "object",
+      "x-relay-connection-type": "pagerduty",
+      "description": "A Relay PagerDuty connection to use",
+      "properties": {
+        "accessToken": {
+          "type": "string",
+          "description": "The PagerDuty API access token to use"
+        }
+      },
+      "required": [
+        "accessToken"
+      ]
+    },
+    "userID": {
+      "type": "string",
+      "description": "A PagerDuty user ID"
+    }
+  },
+  "required": [
+    "userID"
+  ],
+  "additionalProperties": false
+}

--- a/steps/user-get-by-id/step.py
+++ b/steps/user-get-by-id/step.py
@@ -1,0 +1,25 @@
+#!/usr/bin/env python
+
+from sys import exit
+from pdpyras import APISession
+from relay_sdk import Interface, Dynamic as D
+
+relay = Interface()
+
+token = relay.get(D.connection.accessToken)
+session = APISession(token)
+
+userid = relay.get(D.user_id)
+if userid is None:
+    exit("A userID is required, but none was set")
+
+admin_key = relay.get(D.connection.accessToken)
+session = APISession(admin_key)
+
+# https://2.python-requests.org/en/master/api/#requests.Session.request
+# eg https://api.pagerduty.com/users/PHNH11G
+response = session.request("get", "https://api.pagerduty.com/users/" + userid)
+
+relay.outputs.set("response", response.text)
+
+print(response.text)

--- a/steps/user-get-by-id/step.yaml
+++ b/steps/user-get-by-id/step.yaml
@@ -1,0 +1,32 @@
+apiVersion: integration/v1
+kind: Step
+name: user-get-by-id
+version: 1
+summary: PagerDuty User Get By ID Step
+
+description: |
+  This step gets user details from PagerDuty by their PagerDuty ID
+
+schemas:
+  spec:
+    source: file
+    file: spec.schema.json
+
+build:
+  apiVersion: build/v1
+  kind: Docker
+
+publish:
+  repository: relaysh/pagerduty-step-user-get-by-id
+
+schemas:
+  spec:
+    source: file
+    file: spec.schema.json
+  outputs:
+    $schema: 'http://json-schema.org/draft-07/schema#'
+    type: object
+    properties:
+      response:
+        type: string
+    required: [response]

--- a/steps/user-get-by-id/step.yaml
+++ b/steps/user-get-by-id/step.yaml
@@ -24,9 +24,5 @@ schemas:
     source: file
     file: spec.schema.json
   outputs:
-    $schema: 'http://json-schema.org/draft-07/schema#'
-    type: object
-    properties:
-      response:
-        type: string
-    required: [response]
+    source: file
+    file: outputs.schema.json


### PR DESCRIPTION
the webhook v2 trigger assignments come in without user details like email address. User details can be looked up using the incident assignments user ID on the webhook payload with this step, and the email address is one of the properties that the api returns.

this api does require an admin token and not the typical integration key that the other two steps do use.